### PR TITLE
Update RNTone.podspec

### DIFF
--- a/ios/RNTone.podspec
+++ b/ios/RNTone.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNTone
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://www.oliviachang.me/"
   s.license      = "MIT"
   s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "hello@oliviachang.me" }


### PR DESCRIPTION
Pod install fails here because you didn't specify a homepage, must be a new requirement in Cocoapods.
Nice work!